### PR TITLE
Duration: fix error handling when parsing

### DIFF
--- a/internal/utils/duration.go
+++ b/internal/utils/duration.go
@@ -11,6 +11,8 @@ type Duration struct {
 
 func (d *Duration) UnmarshalText(text []byte) error {
 	var err error
-	d.Duration, err = time.ParseDuration(string(text))
-	return fmt.Errorf("could not unmartial duration: %w", err)
+	if d.Duration, err = time.ParseDuration(string(text)); err != nil {
+		return fmt.Errorf("could not unmartial duration: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
PR #24 accidentally introduced a bug in the error handling here as it previously was just returning whatever the error might've been rather than wrapping it with `fmt.Errorf()`. This means that there was always going to be an error generated. The fix is simple: check before wrapping.