### PR TITLE
Fix release process by setting goreleaser config version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 ---
+version: 2
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the release process by setting the version in the goreleaser configuration file to 2.

- **Build**:
    - Set the version in the goreleaser configuration to 2.

<!-- Generated by sourcery-ai[bot]: end summary -->