### PR TITLE
Limit builds and linting of Go code to when it's updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,16 @@
 name: Build
 
 on:
-  - push
-  - pull_request
+  push:
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.*"
+  pull_request:
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.*"
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,17 @@
 name: Lint
 
 on:
-  - push
-  - pull_request
+  push:
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.*"
+  pull_request:
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.*"
+
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request optimizes the CI workflows by limiting the triggers for linting and building to only when Go code files are updated. This reduces unnecessary CI runs and improves efficiency.

- **CI**:
    - Updated linting workflow to trigger only on changes to Go code files.
    - Updated build workflow to trigger only on changes to Go code files.

<!-- Generated by sourcery-ai[bot]: end summary -->