### PR TITLE
Switch to using dorny/paths-filter so PR checks don't hang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - uses: dorny/paths-filter@v3
+        name: check for changes
         id: changes
         with:
           filters: |
@@ -17,9 +20,6 @@ jobs:
               - 'cmd/**'
               - 'internal/**'
               - 'go.*'
-
-      - if: steps.changes.outputs.src == 'true'
-        uses: actions/checkout@v3
 
       - if: steps.changes.outputs.src == 'true'
         name: Set up Go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,16 +2,8 @@
 name: Build
 
 on:
-  push:
-    paths:
-      - "cmd/**"
-      - "internal/**"
-      - "go.*"
-  pull_request:
-    paths:
-      - "cmd/**"
-      - "internal/**"
-      - "go.*"
+  - push
+  - pull_request
 
 jobs:
   build:
@@ -19,15 +11,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Go
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.*'
+
+      - if: steps.changes.outputs.src == 'true'
+        name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
           check-latest: true
           cache: true
 
-      - name: Run tests
+      - if: steps.changes.outputs.src == 'true'
+        name: Run tests
         run: make tests
 
-      - name: Build
+      - if: steps.changes.outputs.src == 'true'
+        name: Build
         run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
       - uses: dorny/paths-filter@v3
         id: changes
         with:
@@ -19,6 +17,9 @@ jobs:
               - 'cmd/**'
               - 'internal/**'
               - 'go.*'
+
+      - if: steps.changes.outputs.src == 'true'
+        uses: actions/checkout@v3
 
       - if: steps.changes.outputs.src == 'true'
         name: Set up Go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,17 +2,8 @@
 name: Lint
 
 on:
-  push:
-    paths:
-      - "cmd/**"
-      - "internal/**"
-      - "go.*"
-  pull_request:
-    paths:
-      - "cmd/**"
-      - "internal/**"
-      - "go.*"
-
+  - push
+  - pull_request
 
 permissions:
   contents: read
@@ -22,14 +13,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
+      - uses: actions/checkout@v4
+    
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.*'
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v6
-      with:
-        version: v1.58
-        args: --issues-exit-code=0
-        only-new-issues: true
+      - if: steps.changes.outputs.src == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - if: steps.changes.outputs.src == 'true'
+        name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.58
+          args: --issues-exit-code=0
+          only-new-issues: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,10 +15,10 @@ linters:
     - ineffassign
 
     # slow, nofix
+    - err113
     - errcheck
     - errname
     - errorlint
-    - goerr113
     - gosimple
     - govet
     - nonamedreturns

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The top-level configuration fields are:
 | timeout | duration | How long to wait when fetching a feed | - |
 | theme | string | The path, relative to _mercury.toml_ of the theme to use | _use default theme_ |
 | output | string | The path, relative to _mercury.toml_ to which _mercury_ should write the files it generates | "./output" |
-| items | number | The number of items to include per page | 10
+| items | number | The number of items to include per page | 10 |
 | max_pages | number | The maximum number of pages to generate | 5 |
 
 A _duration_ is a sequence of numbers followed by a unit, with 's' being 'second', 'm' being 'minute', and 'h' being 'hour'. Thus '5m30' would mean five minutes and thirty seconds.


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflows for linting and building to use dorny/paths-filter, ensuring that steps are only executed when relevant files are changed. Additionally, a minor formatting fix was made to the configuration documentation.

- **Enhancements**:
    - Replaced specific path triggers in GitHub Actions workflows with dorny/paths-filter to conditionally run steps based on file changes.
- **CI**:
    - Updated lint and build GitHub Actions workflows to use dorny/paths-filter for more efficient execution.
- **Documentation**:
    - Fixed a formatting issue in the configuration documentation.

<!-- Generated by sourcery-ai[bot]: end summary -->