### PR TITLE
Switch to distroless/static

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - netgo
+      - timetzdata
 
 brews:
   - name: planet-mercury

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM gcr.io/distroless/static:latest
 
 LABEL org.opencontainers.image.title=Mercury
 LABEL org.opencontainers.image.description="A Planet-style feed aggregator"
@@ -8,7 +8,6 @@ LABEL org.opencontainers.image.url=https://github.com/kgaughan/mercury
 LABEL org.opencontainers.image.source=https://github.com/kgaughan/mercury
 LABEL org.opencontainers.image.documentation=https://kgaughan.github.io/mercury/
 
-RUN apk --no-cache add ca-certificates tzdata
 COPY mercury .
 USER nobody
 ENTRYPOINT ["/mercury"]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 	rm -rf $(NAME) dist site
 
 $(NAME): $(SOURCE) go.sum
-	CGO_ENABLED=0 go build -tags netgo -trimpath -ldflags '-s -w' -o $(NAME) ./cmd/$(NAME)
+	CGO_ENABLED=0 go build -tags netgo,timetzdata -trimpath -ldflags '-s -w' -o $(NAME) ./cmd/$(NAME)
 
 update:
 	go get -u ./...


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the build process by including the 'timetzdata' tag in both the Makefile and .goreleaser.yaml to ensure time zone data is embedded in the binary.

Enhancements:
- Add the 'timetzdata' build tag to the Go build command in the Makefile to include time zone data in the binary.

Build:
- Update the .goreleaser.yaml configuration to include the 'timetzdata' tag in the build process.

<!-- Generated by sourcery-ai[bot]: end summary -->