### PR TITLE
Minor makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,20 @@ NAME:=mercury
 SOURCE:=$(wildcard internal/*.go internal/*/*.go cmd/*/*.go)
 DOCS:=$(wildcard docs/*.md mkdocs.yml)
 
+.PHONY: build
 build: go.mod $(NAME)
 
+.PHONY: tidy
 tidy: go.mod fmt
 
+.PHONY: clean
 clean:
 	rm -rf $(NAME) dist site
 
 $(NAME): $(SOURCE) go.sum
-	CGO_ENABLED=0 go build -tags netgo,timetzdata -trimpath -ldflags '-s -w' -o $(NAME) ./cmd/$(NAME)
+	CGO_ENABLED=0 go build -v -tags netgo,timetzdata -trimpath -ldflags '-s -w' -o $(NAME) ./cmd/$(NAME)
 
+.PHONY: update
 update:
 	go get -u ./...
 	go mod tidy
@@ -24,15 +28,19 @@ go.sum: go.mod
 go.mod: $(SOURCE)
 	go mod tidy
 
+.PHONY: fmt
 fmt:
 	go fmt ./...
 
+.PHONY: lint
 lint:
 	go vet ./...
 
+.PHONY: serve-docs
 serve-docs: .venv
 	.venv/bin/mkdocs serve
 
+.PHONY: docs
 docs: .venv $(DOCS)
 	.venv/bin/mkdocs build
 
@@ -40,12 +48,9 @@ docs: .venv $(DOCS)
 	uv venv
 	uv pip install -r requirements.txt
 
-requirements.txt: requirements.in
+%.txt: %.in
 	uv pip compile $< > $@
 
+.PHONY: tests
 tests:
-	go test -cover ./...
-
-.DEFAULT: build
-
-.PHONY: build clean tidy update fmt lint docs tests serve-docs
+	go test -cover -v ./...


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve the Makefile by adding .PHONY declarations for various targets, enhancing the go build command with verbose output, and simplifying the requirements.txt generation rule.

Enhancements:
- Add verbose flag to the go build command for more detailed output.
- Simplify the requirements.txt generation rule by using a pattern rule.

Build:
- Add .PHONY targets for build, tidy, clean, update, fmt, lint, serve-docs, docs, and tests to improve Makefile phony target handling.

<!-- Generated by sourcery-ai[bot]: end summary -->