### PR TITLE
Add cache directory tagging support

### DIFF
--- a/cmd/mercury/main.go
+++ b/cmd/mercury/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	utils.EnsureDir(config.Cache)
+	utils.EnsureCache(config.Cache)
 
 	if !*flags.NoBuild {
 		utils.EnsureDir(config.Output)

--- a/internal/utils/paths.go
+++ b/internal/utils/paths.go
@@ -1,9 +1,13 @@
 package utils
 
 import (
+	"bytes"
 	"log"
 	"os"
+	"path/filepath"
 )
+
+const cacheTagMarker = "Signature: 8a477f597d28d172789f06886806bc55\n"
 
 func EnsureDir(path string) {
 	if fileInfo, err := os.Stat(path); os.IsNotExist(err) {
@@ -12,5 +16,29 @@ func EnsureDir(path string) {
 		}
 	} else if !fileInfo.IsDir() {
 		log.Fatalf("%s must be a directory\n", path)
+	}
+}
+
+func writeCacheTag(path string) error {
+	return os.WriteFile(path, []byte(cacheTagMarker), 0o600)
+}
+
+func EnsureCache(path string) {
+	EnsureDir(path)
+	cacheTag := filepath.Join(path, "CACHE.TAG")
+	if _, err := os.Stat(cacheTag); os.IsNotExist(err) {
+		if err = writeCacheTag(cacheTag); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		contents, err := os.ReadFile(cacheTag)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !bytes.HasPrefix(contents, []byte(cacheTagMarker)) {
+			if err = writeCacheTag(cacheTag); err != nil {
+				log.Fatal(err)
+			}
+		}
 	}
 }


### PR DESCRIPTION
See: https://bford.info/cachedir/

This is a small tweak to make sure that the cache directory can be identified as such.

## Summary by Sourcery

Add support for cache directory tagging by introducing a standard marker to identify cache directories. Refactor the existing directory creation logic to incorporate this tagging mechanism.

New Features:
- Introduce cache directory tagging to identify cache directories using a standard marker.

Enhancements:
- Refactor the cache directory creation logic to include cache tagging.