### PR TITLE
Allow unwrapped error when writing the cache tag file

### DIFF
--- a/internal/utils/paths.go
+++ b/internal/utils/paths.go
@@ -20,7 +20,7 @@ func EnsureDir(path string) {
 }
 
 func writeCacheTag(path string) error {
-	return os.WriteFile(path, []byte(cacheTagMarker), 0o600)
+	return os.WriteFile(path, []byte(cacheTagMarker), 0o600) //nolint:wrapcheck
 }
 
 func EnsureCache(path string) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Allow unwrapped error when writing the cache tag file by adding a nolint directive.