### PR TITLE
Upgrade toolchain and dependencies where possible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,6 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.61.0
           args: --issues-exit-code=0
           only-new-issues: true

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kgaughan/mercury
 
-go 1.21
+go 1.23
 
-toolchain go1.22.3
+toolchain go1.23.2
 
 require (
 	github.com/BurntSushi/toml v1.4.0
@@ -18,8 +18,8 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.3.0 // indirect
-	github.com/PuerkitoBio/goquery v1.9.3 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
+	github.com/PuerkitoBio/goquery v1.10.0 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,12 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
-github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
-github.com/PuerkitoBio/goquery v1.9.3 h1:mpJr/ikUA9/GNJB/DBZcGeFDXUtosHRyRrwh7KGdTG0=
-github.com/PuerkitoBio/goquery v1.9.3/go.mod h1:1ndLHPdTz+DyQPICCWYlYQMPl0oXZj0G6D4LCYA6u4U=
+github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=
+github.com/PuerkitoBio/goquery v1.10.0/go.mod h1:TjZZl68Q3eGHNBA8CWaxAN7rOU1EbDz3CWuolcO5Yu4=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@
 #    uv pip compile requirements.in
 babel==2.16.0
     # via mkdocs-material
-bracex==2.5
+bracex==2.5.post1
     # via wcmatch
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via mkdocs
@@ -25,7 +25,7 @@ markdown==3.7
     #   mkdocs
     #   mkdocs-material
     #   pymdown-extensions
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   jinja2
     #   mkdocs
@@ -42,13 +42,13 @@ mkdocs-awesome-pages-plugin==2.9.3
     # via -r requirements.in
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-material==9.5.36
+mkdocs-material==9.5.49
     # via -r requirements.in
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 natsort==8.4.0
     # via mkdocs-awesome-pages-plugin
-packaging==24.1
+packaging==24.2
     # via mkdocs
 paginate==0.5.7
     # via mkdocs-material
@@ -58,7 +58,7 @@ platformdirs==4.3.6
     # via mkdocs-get-deps
 pygments==2.18.0
     # via mkdocs-material
-pymdown-extensions==10.9
+pymdown-extensions==10.12
     # via mkdocs-material
 python-dateutil==2.9.0.post0
     # via ghp-import
@@ -70,15 +70,15 @@ pyyaml==6.0.2
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-regex==2024.9.11
+regex==2024.11.6
     # via mkdocs-material
 requests==2.32.3
     # via mkdocs-material
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 urllib3==2.2.3
     # via requests
-watchdog==5.0.2
+watchdog==6.0.0
     # via mkdocs
-wcmatch==9.0
+wcmatch==10.0
     # via mkdocs-awesome-pages-plugin


### PR DESCRIPTION
## Summary by Sourcery

Upgrade various dependencies in requirements.txt and go.mod to their latest versions, including Go toolchain and CI linting action.

Build:
- Upgrade Go toolchain to version 1.23.2 in go.mod.

CI:
- Update golangci-lint-action to version v1.61.0 in the GitHub Actions workflow.