### PR TITLE
Allow for the configuration of the size of the fetch queue and workers

### DIFF
--- a/cmd/mercury/main.go
+++ b/cmd/mercury/main.go
@@ -67,7 +67,7 @@ func main() {
 	// Populate the manifest with the contents of the config file
 	manifest.Populate(config.Feeds)
 	if !*flags.NoFetch {
-		manifest.Prime(config.Cache, config.Timeout.Duration)
+		manifest.Prime(config.Cache, config.Timeout.Duration, config.Parallelism, config.JobQueueDepth)
 	}
 	if err := manifest.Save(manifestPath); err != nil {
 		log.Fatal(err)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 	"sync"
 	"time"
 
@@ -56,13 +55,11 @@ func (m *Manifest) Save(path string) error {
 	return nil
 }
 
-func (m *Manifest) Prime(cache string, timeout time.Duration) {
+func (m *Manifest) Prime(cache string, timeout time.Duration, parallelism, jobQueueDepth int) {
 	var wg sync.WaitGroup
 
-	// The channel depth is kind of arbitrary.
-	jobs := make(chan *fetchJob, 2*runtime.NumCPU())
-
-	for i := 0; i < runtime.NumCPU(); i++ {
+	jobs := make(chan *fetchJob, jobQueueDepth)
+	for i := 0; i < parallelism; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -57,8 +57,8 @@ func (m *Manifest) Save(path string) error {
 
 func (m *Manifest) Prime(cache string, timeout time.Duration, parallelism, jobQueueDepth int) {
 	var wg sync.WaitGroup
-
 	jobs := make(chan *fetchJob, jobQueueDepth)
+
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)
 		go func() {
@@ -77,6 +77,7 @@ func (m *Manifest) Prime(cache string, timeout time.Duration, parallelism, jobQu
 			Item: item,
 		}
 	}
+
 	close(jobs)
 	wg.Wait()
 }


### PR DESCRIPTION
The defaults should be fine in 99% of cases, but some may want to tune them down on more powerful machines.

## Summary by Sourcery

Add configuration options for job queue depth and parallelism to allow tuning of fetch operations, with a cap on CPU usage to enhance performance.

New Features:
- Introduce configuration options for job queue depth and parallelism in the fetch process.

Enhancements:
- Cap the number of CPUs/cores used to a maximum of 32 to optimize performance.