### PR TITLE
Fix linter issues that look as if they're down to toolchain updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,6 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.8
           args: --issues-exit-code=0
           only-new-issues: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,7 @@ linters:
     - nonamedreturns
     - revive
     - staticcheck
-    - tenv
+    - usetesting
     - typecheck
     - unconvert
     - unused

--- a/internal/manifest/cacheitem.go
+++ b/internal/manifest/cacheitem.go
@@ -84,11 +84,8 @@ func (ci *cacheItem) Fetch(feedURL, cacheDir string, timeout time.Duration) erro
 			return fmt.Errorf("can't parse %s: %w", feedURL, err)
 		} else if file, err := json.Marshal(feed); err != nil {
 			return fmt.Errorf("can't marshal %s: %w", feedURL, err)
-		} else {
-			// Save to the cache
-			if err := os.WriteFile(cacheFile, file, 0o600); err != nil {
-				return fmt.Errorf("can't write to cache: %w", err)
-			}
+		} else if err := os.WriteFile(cacheFile, file, 0o600); err != nil {
+			return fmt.Errorf("can't write to cache: %w", err)
 		}
 
 	default:

--- a/internal/templates/excerpt.go
+++ b/internal/templates/excerpt.go
@@ -12,12 +12,12 @@ import (
 
 const ellipsis = '\u2026'
 
-func excerpt(text string, max int) string {
+func excerpt(text string, maxlen int) string {
 	var b strings.Builder
 
 	t := html.NewTokenizer(strings.NewReader(text))
 
-	remaining := max
+	remaining := maxlen
 	tagStack := make([]string, 0, 16) // This should be plenty to avoid reallocation
 
 Loop:

--- a/internal/templates/functions.go
+++ b/internal/templates/functions.go
@@ -23,8 +23,8 @@ func configureFunctions() *template.Template {
 		"sanitize": func(text template.HTML) template.HTML {
 			return template.HTML(p.Sanitize(string(text))) //nolint:gosec
 		},
-		"excerpt": func(max int, text template.HTML) template.HTML {
-			return template.HTML(excerpt(string(text), max)) //nolint:gosec
+		"excerpt": func(maxlen int, text template.HTML) template.HTML {
+			return template.HTML(excerpt(string(text), maxlen)) //nolint:gosec
 		},
 	}).Funcs(sprig.FuncMap())
 }


### PR DESCRIPTION
## Summary by Sourcery

Update linter configuration and fix minor code style issues across multiple files

Bug Fixes:
- Simplified error handling and nested conditionals in cacheitem.go to improve code readability

Enhancements:
- Renamed function parameters for clarity in templates package

CI:
- Updated golangci-lint workflow to use a newer version (v1.64.8)
- Updated .golangci.yaml linter configuration