### PR TITLE
Bump requests to 2.32.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ pyyaml==6.0.2
     #   pyyaml-env-tag
 pyyaml-env-tag==1.1
     # via mkdocs
-requests==2.32.3
+requests==2.32.4
     # via mkdocs-material
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
Fixes #136.

## Summary by Sourcery

Update the requests dependency to patch version 2.32.4 to resolve issue #136.

Bug Fixes:
- Resolve issue #136 by upgrading requests to 2.32.4.

Build:
- Bump requests version in requirements.txt from 2.32.3 to 2.32.4.