### PR TITLE
Logging improvements

### DIFF
--- a/cmd/mercury/main.go
+++ b/cmd/mercury/main.go
@@ -81,15 +81,18 @@ func main() {
 	}
 
 	if !*flags.NoBuild {
+		log.Printf("Finding most recent %d entries across %d feeds", config.ItemsPerPage*config.MaxPages, len(feeds))
 		entries := fq.Shuffle(config.ItemsPerPage * config.MaxPages)
 		if err := writePages(entries, feeds, config, tmpl); err != nil {
 			log.Fatal(err)
 		}
 
+		log.Print("Writing Atom feed")
 		if err := writeFeed(entries, config); err != nil {
 			log.Fatal(err)
 		}
 
+		log.Print("Writing OPML file")
 		if err := manifest.AsOPML().Save(path.Join(config.Output, "opml.xml")); err != nil {
 			log.Fatal(err)
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -77,6 +77,7 @@ func (m *Manifest) Prime(cache string, timeout time.Duration, parallelism, jobQu
 	var wg sync.WaitGroup
 	jobs := make(chan *fetchJob, jobQueueDepth)
 
+	log.Printf("Priming manifest with %d feeds using %d workers, with a queue depth of %d", len(*m), parallelism, jobQueueDepth)
 	for range parallelism {
 		wg.Add(1)
 		go func() {
@@ -86,6 +87,7 @@ func (m *Manifest) Prime(cache string, timeout time.Duration, parallelism, jobQu
 				if job == nil || job.Item == nil {
 					continue
 				}
+				log.Print("Fetching ", job.URL)
 				if err := job.Item.Fetch(ctx, job.URL, cache, timeout); err != nil {
 					log.Print(err)
 				}


### PR DESCRIPTION
## Summary by Sourcery

Add logging statements to surface progress during feed processing and manifest priming

Enhancements:
- Log the number of entries and feeds when shuffling entries
- Log when writing the Atom feed and OPML file
- Log manifest priming details including feed count, worker count, and queue depth
- Log fetching each job URL during manifest priming