### PR TITLE
Fall back to publication date if updated date is nil

### DIFF
--- a/internal/feed/entry.go
+++ b/internal/feed/entry.go
@@ -94,7 +94,11 @@ func (e Entry) Published() *time.Time {
 
 // Updated returns the update date of the entry.
 func (e Entry) Updated() *time.Time {
-	return e.entry.UpdatedParsed
+	if e.entry.UpdatedParsed != nil {
+		return e.entry.UpdatedParsed
+	}
+	// Fallback
+	return e.entry.PublishedParsed
 }
 
 // Categories returns the entry's categories.

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -52,6 +52,7 @@ func (m *Manifest) Len() int {
 	return len(*m)
 }
 
+// Save writes the manifest to a file.
 func (m *Manifest) Save(path string) error {
 	file, err := json.Marshal(m)
 	if err != nil {


### PR DESCRIPTION
I don't know why I didn't hit this sooner.

## Summary by Sourcery

Enhance entry date handling by returning the published date if the updated date is unavailable and improve code documentation for the manifest Save method.

Bug Fixes:
- Provide a fallback to publication date when an entry's updated date is nil

Documentation:
- Add documentation comment for Manifest.Save method