### PR TITLE
Add comments and rename cacheItem to cacheEntry

### DIFF
--- a/internal/feed/entry.go
+++ b/internal/feed/entry.go
@@ -106,6 +106,7 @@ func (e Entry) Categories() []string {
 	return e.entry.Categories
 }
 
+// ID returns a unique identifier for the entry.
 func (e Entry) ID() string {
 	if e.entry.GUID != "" {
 		return e.entry.GUID

--- a/internal/manifest/cacheitem.go
+++ b/internal/manifest/cacheitem.go
@@ -16,7 +16,9 @@ import (
 )
 
 // TODO if a feed is fetched, it shouldn't need to be loaded.
-type cacheItem struct {
+
+// cacheEntry represents the metadata of a cached feed.
+type cacheEntry struct {
 	Name         string
 	UUID         string    // Used to identify the cached feed
 	LastModified string    // Used for conditional GET
@@ -24,7 +26,9 @@ type cacheItem struct {
 	Expires      time.Time // Date after which we should ignore the cache
 }
 
-func (ci *cacheItem) Fetch(ctx context.Context, feedURL, cacheDir string, timeout time.Duration) error {
+// Fetch retrieves the feed from the given URL, using conditional GET
+// headers if available, and updates the cache entry metadata accordingly.
+func (ci *cacheEntry) Fetch(ctx context.Context, feedURL, cacheDir string, timeout time.Duration) error {
 	cacheFile := filepath.Join(cacheDir, ci.UUID+".json")
 	// Blank headers if the cached feed doesn't exist
 	if _, err := os.Stat(cacheFile); os.IsNotExist(err) {
@@ -98,7 +102,8 @@ func (ci *cacheItem) Fetch(ctx context.Context, feedURL, cacheDir string, timeou
 	return nil
 }
 
-func (ci *cacheItem) Load(cacheDir string) (*gofeed.Feed, error) {
+// Load retrieves the cached feed from disk.
+func (ci *cacheEntry) Load(cacheDir string) (*gofeed.Feed, error) {
 	cacheFile := filepath.Join(cacheDir, ci.UUID+".json")
 	file, err := os.ReadFile(cacheFile)
 	if err != nil {

--- a/internal/manifest/feed.go
+++ b/internal/manifest/feed.go
@@ -1,5 +1,6 @@
 package manifest
 
+// Feed represents a feed entry in the manifest.
 type Feed struct {
 	Name string
 	Feed string

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -13,13 +13,16 @@ import (
 	"github.com/kgaughan/mercury/internal/opml"
 )
 
-type Manifest map[string]*cacheItem
+// Manifest maps feed URLs to their cache metadata.
+type Manifest map[string]*cacheEntry
 
+// fetchJob represents a job to fetch a feed and update its cache item.
 type fetchJob struct {
 	URL  string
-	Item *cacheItem
+	Item *cacheEntry
 }
 
+// LoadManifest loads the manifest from a file.
 func LoadManifest(path string) (*Manifest, error) {
 	manifest := &Manifest{}
 	file, err := os.ReadFile(path)
@@ -36,11 +39,12 @@ func LoadManifest(path string) (*Manifest, error) {
 	return manifest, nil
 }
 
+// Populate adds feeds to the manifest.
 func (m *Manifest) Populate(feeds []Feed) {
 	for _, feed := range feeds {
 		if _, ok := (*m)[feed.Feed]; !ok {
 			// New feed: create a new record
-			(*m)[feed.Feed] = &cacheItem{
+			(*m)[feed.Feed] = &cacheEntry{
 				Name: feed.Name,
 				UUID: uuid.New().String(),
 			}
@@ -48,6 +52,7 @@ func (m *Manifest) Populate(feeds []Feed) {
 	}
 }
 
+// Len returns the number of feeds in the manifest.
 func (m *Manifest) Len() int {
 	return len(*m)
 }

--- a/internal/templates/excerpt.go
+++ b/internal/templates/excerpt.go
@@ -12,6 +12,8 @@ import (
 
 const ellipsis = '\u2026'
 
+// excerpt generates an excerpt from the provided HTML text, truncating it to
+// the specified maximum length while preserving HTML structure.
 func excerpt(text string, maxlen int) string {
 	var b strings.Builder
 
@@ -64,6 +66,9 @@ Loop:
 	return b.String()
 }
 
+// truncateText truncates the input text to fit within the remaining character
+// limit, ensuring that words are not cut in half. It returns the truncated
+// text and the number of remaining characters after truncation.
 func truncateText(text string, remaining int) (string, int) {
 	lastSpace := -1
 	for n, r := range text {

--- a/internal/templates/functions.go
+++ b/internal/templates/functions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 )
 
+// configureFunctions sets up the template functions available in the templates.
 func configureFunctions() *template.Template {
 	// This is just a starting point so there's a reasonable policy
 	p := bluemonday.UGCPolicy()
@@ -29,6 +30,7 @@ func configureFunctions() *template.Template {
 	}).Funcs(sprig.FuncMap())
 }
 
+// Configure loads and configures templates from the provided filesystem.
 func Configure(themeFS fs.FS) (*template.Template, error) {
 	//nolint:wrapcheck
 	return configureFunctions().ParseFS(themeFS, "*.html")

--- a/internal/theme/config.go
+++ b/internal/theme/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	BOM  []BOMEntry `toml:"bom"`
 }
 
+// BOMEntry describes a single entry in the theme's bill of materials.
 type BOMEntry struct {
 	Path string `toml:"path"`
 }
@@ -29,6 +30,8 @@ func (c *Config) Load(themeFS fs.FS) error {
 	return nil
 }
 
+// CopyTo copies the theme's bill of materials into the specified destination
+// directory.
 func (c *Config) CopyTo(destDir string) error {
 	for _, entry := range c.BOM {
 		src, err := c.root.Open(entry.Path)

--- a/internal/utils/cachecontrol.go
+++ b/internal/utils/cachecontrol.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pquerna/cachecontrol/cacheobject"
 )
 
+// ParseCacheControlExpiration parses the Cache-Control header and sets the
+// expiration time based on its directives.
 func ParseCacheControlExpiration(cc string, expires *time.Time) error {
 	resDir, err := cacheobject.ParseResponseCacheControl(cc)
 	if err != nil {

--- a/internal/utils/copy.go
+++ b/internal/utils/copy.go
@@ -7,6 +7,8 @@ import (
 	"path"
 )
 
+// Copy copies data from src to a file at destPath, creating any necessary
+// directories along the way.
 func Copy(src io.Reader, destPath string) error {
 	dirPath := path.Dir(destPath)
 	if err := os.MkdirAll(dirPath, 0o755); err != nil {

--- a/internal/utils/duration.go
+++ b/internal/utils/duration.go
@@ -5,10 +5,14 @@ import (
 	"time"
 )
 
+// Duration is a wrapper around time.Duration that supports unmarshaling from
+// text.
 type Duration struct {
 	time.Duration
 }
 
+// UnmarshalText implements the encoding.TextUnmarshaler interface for our
+// Duration type.
 func (d *Duration) UnmarshalText(text []byte) error {
 	var err error
 	if d.Duration, err = time.ParseDuration(string(text)); err != nil {

--- a/internal/utils/paths.go
+++ b/internal/utils/paths.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 )
 
+// cacheTagMarker is the standard marker for cache directories.
 const cacheTagMarker = "Signature: 8a477f597d28d172789f06886806bc55\n"
 
+// EnsureDir ensures that the specified path exists and is a directory.
 func EnsureDir(path string) {
 	if fileInfo, err := os.Stat(path); os.IsNotExist(err) {
 		if err := os.MkdirAll(path, 0o755); err != nil {
@@ -19,10 +21,12 @@ func EnsureDir(path string) {
 	}
 }
 
+// writeCacheTag writes the cache tag file at the specified path.
 func writeCacheTag(path string) error {
 	return os.WriteFile(path, []byte(cacheTagMarker), 0o600) //nolint:wrapcheck
 }
 
+// EnsureCache ensures that the specified path is a valid cache directory.
 func EnsureCache(path string) {
 	EnsureDir(path)
 	cacheTag := filepath.Join(path, "CACHE.TAG")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,10 +7,12 @@ var Version string
 
 const repo = "https://github.com/kgaughan/mercury/"
 
+// UserAgent returns the User-Agent string for HTTP requests.
 func UserAgent() string {
 	return fmt.Sprintf("planet-mercury/%v (%v)", Version, repo)
 }
 
+// Generator returns the generator string for feed generation.
 func Generator() string {
 	return fmt.Sprintf("Planet Mercury %v (%v)", Version, repo)
 }


### PR DESCRIPTION
## Summary by Sourcery

Rename cacheItem to cacheEntry and enrich internal packages with documentation for types and functions

Enhancements:
- Rename cacheItem to cacheEntry in the manifest package and update associated structs and references
- Add documentation comments for cacheEntry methods and Manifest functions (LoadManifest, Populate, Len)
- Document utility types and functions across internal packages including Duration.UnmarshalText, EnsureDir, writeCacheTag, EnsureCache, ParseCacheControlExpiration, Copy
- Add doc comments for template helpers (excerpt, truncateText, configureFunctions, Configure), version utilities (UserAgent, Generator), feed Entry.ID, BOMEntry, and Feed types