### PR TITLE
Don't bother caching setup-go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
 
       - if: steps.changes.outputs.src == 'true'
         name: Run tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-    
+
       - uses: dorny/paths-filter@v3
         id: changes
         with:
@@ -29,7 +29,6 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
 
       - if: steps.changes.outputs.src == 'true'
         name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 concurrency:
   group: releaser
@@ -32,7 +32,6 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
It always pulls down the go toolchain, so it's pointless.

## Summary by Sourcery

Remove setup-go caching from GitHub workflows and clean up YAML formatting

Enhancements:
- Drop the cache: true option from setup-go steps in lint, build, and release workflows
- Normalize tag pattern quotes from single to double in the release workflow
- Remove extraneous whitespace in the workflow YAML files