### PR TITLE
Allow theme, output, and cache to be absolute paths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,8 @@ The top-level configuration fields are:
 | items | number | The number of items to include per page | 10 |
 | max_pages | number | The maximum number of pages to generate | 5 |
 
+Note that the `theme`, `output`, and `cache` paths are assumed to be relative to the directory in which the configuration file is found, not the current working directory. You can specify absolute paths in these fields, however.
+
 A _duration_ is a sequence of numbers followed by a unit, with 's' being 'second', 'm' being 'minute', and 'h' being 'hour'. Thus '5m30' would mean five minutes and thirty seconds.
 
 The feed ID is a URI identifying the feed. I would recommend using a [tag URI](https://en.wikipedia.org/wiki/Tag_URI_scheme), or a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) [URN](https://en.wikipedia.org/wiki/Uniform_Resource_Name). In the latter case, use a UUID generator such as `uuidgen` to generate a UUID, prefix it with `urn:uuid:`, and use the result as the value of `feed_id`.

--- a/internal/config.go
+++ b/internal/config.go
@@ -58,16 +58,25 @@ func (c *Config) Load(path string) error {
 	c.Parallelism = min(max(1, c.Parallelism), cpuLimit)
 	c.JobQueueDepth = max(2*c.Parallelism, c.JobQueueDepth)
 
-	c.Cache = filepath.Join(configDir, c.Cache)
+	if !filepath.IsAbs(c.Cache) {
+		c.Cache = filepath.Join(configDir, c.Cache)
+	}
 	if c.themePath == "" {
 		c.Theme = dflt.Theme
 	} else {
-		themePath := filepath.Join(configDir, c.themePath)
+		var themePath string
+		if !filepath.IsAbs(c.themePath) {
+			themePath = c.themePath
+		} else {
+			themePath = filepath.Join(configDir, c.themePath)
+		}
 		if _, err := os.Stat(themePath); os.IsNotExist(err) {
 			return fmt.Errorf("theme %q not found: %w", themePath, err)
 		}
 		c.Theme = os.DirFS(themePath)
 	}
-	c.Output = filepath.Join(configDir, c.Output)
+	if !filepath.IsAbs(c.Output) {
+		c.Output = filepath.Join(configDir, c.Output)
+	}
 	return nil
 }


### PR DESCRIPTION
filepath.Join behaved in an unexpected manner: I'd wrongly assumed that an absolute path in any of the parameters would lead the proceeding values to be discarded.

## Summary by Sourcery

Allow theme, output, and cache configuration fields to accept absolute paths by only joining relative values with the config directory and update the docs to explain this behavior

Enhancements:
- Preserve absolute paths for cache, theme, and output instead of always resolving them relative to the configuration directory

Documentation:
- Clarify in the configuration documentation that theme, output, and cache paths default to being relative to the config file’s directory but may be specified as absolute paths