### PR TITLE
Tests for Cache-Control

### DIFF
--- a/internal/utils/cachecontrol.go
+++ b/internal/utils/cachecontrol.go
@@ -13,9 +13,10 @@ func ParseCacheControlExpiration(cc string, expires *time.Time) error {
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
-	*expires = time.Now().UTC()
 	if !resDir.NoCachePresent && resDir.MaxAge > 0 {
-		*expires = expires.Add(time.Second * time.Duration(resDir.MaxAge))
+		*expires = time.Now().UTC().Add(time.Second * time.Duration(resDir.MaxAge))
+	} else {
+		*expires = time.Time{}
 	}
 	return nil
 }

--- a/internal/utils/cachecontrol_test.go
+++ b/internal/utils/cachecontrol_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCacheControlExpiration(t *testing.T) {
+	tests := []struct {
+		name          string
+		cc            string
+		expectExpires bool
+		minDuration   time.Duration
+		maxDuration   time.Duration
+	}{
+		{
+			name:          "no cache control",
+			cc:            "",
+			expectExpires: false,
+		},
+		{
+			name:          "no-cache directive",
+			cc:            "no-cache",
+			expectExpires: false,
+		},
+		{
+			name:          "max-age directive",
+			cc:            "max-age=60",
+			expectExpires: true,
+			minDuration:   59 * time.Second,
+			maxDuration:   61 * time.Second,
+		},
+		{
+			name:          "no-cache and max-age directives",
+			cc:            "no-cache, max-age=120",
+			expectExpires: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var expires time.Time
+			err := ParseCacheControlExpiration(tt.cc, &expires)
+			if err != nil {
+				t.Fatalf("ParseCacheControlExpiration returned error: %v", err)
+			}
+
+			if tt.expectExpires {
+				if expires.IsZero() {
+					t.Errorf("expected expires to be set, but it is zero")
+				} else {
+					duration := time.Until(expires)
+					if duration < tt.minDuration || duration > tt.maxDuration {
+						t.Errorf("expires duration %v not within expected range [%v, %v]", duration, tt.minDuration, tt.maxDuration)
+					}
+				}
+			} else {
+				if !expires.IsZero() {
+					t.Errorf("expected expires to be zero, but got %v", expires)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

Improve cache-control expiration logic to consistently use the current time and clear expiration when appropriate, and introduce tests to validate various directive scenarios

Enhancements:
- Use the current time directly when computing the cache expiration and reset expires to zero when no valid max-age applies

Tests:
- Add unit tests for ParseCacheControlExpiration covering no-cache, missing directives, max-age, and combined directives