### PR TITLE
Remove feeds no longer in the configuration from the manifest

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -41,13 +41,23 @@ func LoadManifest(path string) (*Manifest, error) {
 
 // Populate adds feeds to the manifest.
 func (m *Manifest) Populate(feeds []Feed) {
+	// The value is a dummy: we're just using the map as a set
+	liveFeedUrls := make(map[string]struct{})
 	for _, feed := range feeds {
+		liveFeedUrls[feed.Feed] = struct{}{}
 		if _, ok := (*m)[feed.Feed]; !ok {
 			// New feed: create a new record
 			(*m)[feed.Feed] = &cacheEntry{
 				Name: feed.Name,
 				UUID: uuid.New().String(),
 			}
+		}
+	}
+	// Remove any feeds no longer in the config
+	for url := range *m {
+		if _, ok := liveFeedUrls[url]; !ok {
+			log.Printf("Removing feed %q from manifest", url)
+			delete(*m, url)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #162.

This behaviour was never intentional: the manifest is meant to tell us what files in the cache correspond to feeds and to provide metadata to avoid fetching feeds that are still fresh.

This doesn't purge the actual cache entries, however. I might add something to do that later.

## Summary by Sourcery

Prune manifest entries for feeds that are no longer in the provided configuration during the Populate step.

Bug Fixes:
- Remove manifest entries for feeds that are not present in the current configuration

Enhancements:
- Introduce a set of live feed URLs to efficiently detect and delete stale entries