### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          # to allow us to push to the repo later
+          persist-credentials: true
 
       - name: Install Python
         uses: actions/setup-python@v6

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ NAME:=mercury
 SOURCE:=$(wildcard internal/*.go internal/*/*.go cmd/*/*.go)
 DOCS:=$(wildcard docs/*.md mkdocs.yml)
 
+.DEFAULT_GOAL:=build
+
 .PHONY: help
 help: ## Show this help message
 	@echo "Usage: make [target]"
@@ -53,7 +55,7 @@ docs: .venv $(DOCS) ## Build the documentation site
 	uv run mkdocs build
 
 .venv: requirements.txt
-	uv venv
+	uv venv --clear
 	uv pip install -r requirements.txt
 
 %.txt: %.in


### PR DESCRIPTION
## Summary by Sourcery

Set the default Make target to build, ensure Python virtual environments are recreated cleanly, and adjust the docs CI workflow to retain GitHub credentials for pushing changes.

Build:
- Set the default Makefile target to `build` and recreate the Python virtual environment with `uv venv --clear` to avoid stale environments.

CI:
- Update the docs GitHub Actions workflow to persist GitHub credentials so the job can push changes back to the repository.