### PR TITLE
Switch to using the pandoc binary

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: pandoc/actions/setup@v1
         with:
-          verson: 3.9
+          version: 3.1.11.1
 
       - name: Build with pandoc
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,23 +27,23 @@ jobs:
       - uses: actions/configure-pages@v6.0.0
         id: pages
 
-      - name: Build with pandoc
-        uses: docker://pandoc/core:3.9
-        working-directory: docs
+      - uses: pandoc/actions/setup@v1
         with:
-          args: >-
-            index.md
-            --standalone
-            --from markdown
-            --to chunkedhtml
-            --variable toc
-            --toc-depth 2
-            --chunk-template "%i.html"
-            --template template.html
-            --highlight-style solarizeddark.theme
-            --output "../site"
+          verson: 3.9
 
-      - run: find site -type f
+      - name: Build with pandoc
+        working-directory: docs
+        run: |
+          pandoc index.md \
+            --standalone \
+            --from markdown \
+            --to chunkedhtml \
+            --variable toc \
+            --toc-depth 2 \
+            --chunk-template "%i.html" \
+            --template template.html \
+            --highlight-style solarizeddark.theme \
+            --output "../site"
 
       - uses: actions/upload-pages-artifact@v4.0.0
         with:


### PR DESCRIPTION
It appears that `working-directory` only works with `run`, not `uses`.

## Summary by Sourcery

Build:
- Update the docs GitHub Actions workflow to install pandoc via pandoc/actions/setup and invoke it from a run step in the docs working directory.