### PR TITLE
Switch to 'make docs' for consistency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,18 +32,7 @@ jobs:
           version: 3.1.11.1
 
       - name: Build with pandoc
-        working-directory: docs
-        run: |
-          pandoc index.md \
-            --standalone \
-            --from markdown \
-            --to chunkedhtml \
-            --variable toc \
-            --toc-depth 2 \
-            --chunk-template "%i.html" \
-            --template template.html \
-            --highlight-style solarizeddark.theme \
-            --output "../site"
+        run: make docs
 
       - uses: actions/upload-pages-artifact@v4.0.0
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the docs GitHub Actions workflow to build documentation via `make docs` for consistency with the rest of the project.