### PR TITLE
Remove Python from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This was only present for mkdocs.

## Summary by Sourcery

Build:
- Remove the pip ecosystem entry from Dependabot configuration, leaving only GitHub Actions updates enabled.