### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4.0.1
         name: check for changes
         id: changes
         with:
@@ -33,7 +33,7 @@ jobs:
 
       - if: steps.changes.outputs.src == 'true'
         name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
 
       - uses: actions/configure-pages@v6.0.0
         id: pages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4.0.1
         id: changes
         with:
           filters: |
@@ -31,7 +31,7 @@ jobs:
               - 'go.*'
 
       - if: steps.changes.outputs.src == 'true'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
@@ -41,6 +41,6 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
-          version: v2.11.3
+          version: v2.11.4
           args: --issues-exit-code=0
           only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,20 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
           cache: false
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7.1.0
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflows to use newer versions of core actions and tools.

Build:
- Bump actions/checkout to v6.0.2 across lint, build, release, and docs workflows.
- Bump dorny/paths-filter to v4.0.1 in lint and build workflows.
- Update actions/setup-go to v6.4.0 in lint, build, and release workflows.
- Upgrade goreleaser/goreleaser-action to v7.1.0 in the release workflow.
- Align golangci-lint-action configuration to use golangci-lint v2.11.4 in the lint workflow.