### PR TITLE
Periodically scan for issues with govulncheck

### DIFF
--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -1,0 +1,34 @@
+---
+name: Flag vulnerabilities with govulncheck
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  schedule:
+    - cron: "0 3 * * 5"  # 3am, every Friday
+  workflow_dispatch:
+
+jobs:
+  vulns:
+    name: Flag vulnerabilities with govulncheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # To allow sarif file to be uploaded
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1.1.0
+        output-format: sarif
+        output-file: govulncheck-results.sarif
+
+      - name: Upload scan results to GitHub security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: govulncheck-results.sarif

--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -25,8 +25,9 @@ jobs:
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1.1.0
-        output-format: sarif
-        output-file: govulncheck-results.sarif
+        with:
+          output-format: sarif
+          output-file: govulncheck-results.sarif
 
       - name: Upload scan results to GitHub security tab
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow that runs govulncheck on pushes, version tags, a weekly schedule, and manual dispatch, uploading SARIF results to the Security tab.