### PR TITLE
Fix the doc build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - if: steps.changes.outputs.src == 'true'
         name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           version: 3.1.11.1
 
-      - uses: pandoc/actions/setup@v1
+      - uses: extractions/setup-just@v4
         with:
-          version: 3.1.11.1
+          just-version: 1.40.0
 
       - name: Build with pandoc
         run: just docs


### PR DESCRIPTION
## Summary by Sourcery

Update documentation build workflow to use the Just command runner and refresh Go setup action in the build workflow.

Build:
- Switch docs workflow from pandoc setup action to setup-just with pinned Just version.
- Upgrade Go setup action in build workflow to actions/setup-go@v7.